### PR TITLE
Zustandを使って認証状態を管理ログイン状態でHeaderメニューを切り替え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,10 @@ yarn-error.log*
 next-env.d.ts
 
 # github_
-.github
+.github/copilot-instructions*
 
 # vscode
 .vscode
+
+# cursor
+/.cursor/

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter"
 import QueryProviders from "./queryClientProvider";
 import { Suspense } from "react";
 import LoadingErrorContainer from "@/components/feedback/LoadingErrorContainer";
+import { AuthProvider } from "@/components/auth/AuthProvider";
 
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
@@ -32,9 +33,11 @@ export default function RootLayout({
       >
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
           <QueryProviders>
-            <Suspense fallback={<LoadingErrorContainer loading={true} />}>
-              {children}
-            </Suspense>
+            <AuthProvider>
+              <Suspense fallback={<LoadingErrorContainer loading={true} />}>
+                {children}
+              </Suspense>
+            </AuthProvider>
           </QueryProviders>
         </AppRouterCacheProvider>
       </body>

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -80,7 +80,17 @@ export function AuthForm({ mode }: AuthFormProps) {
         <Box
             component="form"
             onSubmit={handleSubmit(onSubmit)}
-            sx={{ maxWidth: 540, mx: "auto", p: 4, backgroundColor: "grey.300", color: "grey.700" }}
+            sx={{
+                maxWidth: 540,
+                mx: "auto",
+                p: 4,
+                backgroundColor: "grey.300",
+                color: "grey.700",
+                borderRadius: 2,
+                boxShadow: 2,
+                height: "100vh",
+                overflowY: "auto"
+            }}
         >
             <Typography variant="h5" fontWeight="bold" textAlign="center">
                 {isSignup ? "アカウント作成" : "ログイン"}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { useAuthStore } from "@/lib/AuthStore"
+import { useEffect } from "react"
+
+interface AuthProviderProps {
+    children: React.ReactNode
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+    const initialize = useAuthStore((state) => state.initialize)
+    useEffect(() => {
+        const unsubscribe = initialize()
+        return unsubscribe
+    }, [initialize])
+
+    return <>{children}</>
+}

--- a/src/lib/AuthStore.ts
+++ b/src/lib/AuthStore.ts
@@ -1,0 +1,31 @@
+import { onAuthStateChanged, User } from "firebase/auth"
+import { create } from "zustand"
+import { auth } from "./firebase";
+
+interface AuthStore {
+    user: User | null;
+    isLoading: boolean;
+    isAuthenticated: boolean;
+    setUser: (user: User | null) => void;
+    setLoading: (loading: boolean) => void;
+    initialize: () => void;
+}
+
+export const useAuthStore = create<AuthStore>((set, get) => ({
+    user: null,
+    isLoading: true,
+    isAuthenticated: false,
+    setUser: (user: User | null) => {
+        set({ user, isAuthenticated: !!user, isLoading: false })
+    },
+    setLoading: (loading: boolean) => {
+        set({ isLoading: loading })
+    },
+    initialize: () => {
+        const unsubscribe = onAuthStateChanged(auth, (user) => {
+            get().setUser(user)
+        })
+        // クリーンアップ関数を返す
+        return unsubscribe
+    }
+}))


### PR DESCRIPTION
- Zusutand用のフックを作成（AuthStore）
- AuthProviderのマウントを設定（layout）
- ログイン・未ログインでのメニュー切り替え（Header）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced centralized authentication state management, improving login status detection and menu rendering.
  - Added an authentication provider to ensure authentication state is available throughout the app.

- **Enhancements**
  - Improved the visual styling and layout of the authentication form for a better user experience.
  - Updated navigation menus to reflect authentication status and added a loading state during authentication checks.

- **Chores**
  - Updated file ignore rules for better project organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->