### PR TITLE
ブラウザのHTMLエラー対応

### DIFF
--- a/src/app/stores/images/[id]/edit/[imageId]/page.tsx
+++ b/src/app/stores/images/[id]/edit/[imageId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
-import { Alert, Box, Button, CircularProgress, Divider, MenuItem, TextField, Typography } from '@mui/material'
+import { Alert, Box, Button, CircularProgress, Divider, FormControl, InputLabel, MenuItem, Select, TextField, Typography } from '@mui/material'
 import { useAuthStore } from '@/lib/AuthStore'
 import { Controller, useForm } from 'react-hook-form'
 import { imageEditFormSchema, ImageEditFormValues, validateFileSizeBeforeCompression } from '@/validations/image'
@@ -237,17 +237,23 @@ export default function ImageUpdatePage() {
                         </Button>
                     </Box>
                 ) : (
-                    <Button variant='outlined' color='primary' component="label"
-                        className='mb-2 w-full'
-                    >
-                        画像を変更
-                        <input
-                            type="file"
-                            hidden
-                            accept="image/jpeg,image/png,image/gif,image/webp"
-                            onChange={handleImageChange}
-                        />
-                    </Button>
+                    <label htmlFor="image-edit-input">
+                        <Button
+                            variant='outlined'
+                            color='primary'
+                            component="span"
+                            className='mb-2 w-full'
+                        >
+                            画像を変更
+                            <input
+                                id="image-edit-input"
+                                type="file"
+                                hidden
+                                accept="image/jpeg,image/png,image/gif,image/webp"
+                                onChange={handleImageChange}
+                            />
+                        </Button>
+                    </label>
                 )}
                 {errors.imageFile && (
                     <Typography color='error' variant='body2' className='mt-2'>
@@ -264,16 +270,26 @@ export default function ImageUpdatePage() {
                 <Controller
                     name='menuType' control={control}
                     render={({ field }) => (
-                        <TextField
-                            select label="メニュータイプ" {...field}
-                            fullWidth className='mb-6' size='small' required
-                        >
-                            {MENU_TYPE.map(menu => (
-                                <MenuItem key={menu.value} value={menu.value}>
-                                    {menu.label}
-                                </MenuItem>
-                            ))}
-                        </TextField>
+                        <FormControl fullWidth size="small" required>
+                            <InputLabel
+                                id="menu-type-label"
+                            >メニュータイプ
+                            </InputLabel>
+                            <Select
+                                {...field}
+                                labelId="menu-type-label"
+                                id="menu-type"
+                                label="メニュータイプ"
+                                fullWidth
+                                className="mb-4"
+                            >
+                                {MENU_TYPE.map(menu => (
+                                    <MenuItem key={menu.value} value={menu.value}>
+                                        {menu.label}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
                     )}
                 />
                 <Controller

--- a/src/app/stores/images/[id]/upload/page.tsx
+++ b/src/app/stores/images/[id]/upload/page.tsx
@@ -9,7 +9,7 @@ import React, { useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import imageCompression from "browser-image-compression"
 import LoadingErrorContainer from "@/components/feedback/LoadingErrorContainer"
-import { Alert, Box, Button, CircularProgress, Divider, MenuItem, TextField, Typography } from "@mui/material"
+import { Alert, Box, Button, CircularProgress, Divider, FormControl, InputLabel, MenuItem, Select, TextField, Typography } from "@mui/material"
 import Image from "next/image"
 import { ToppingOptionRadioSelector } from "@/components/toppingCallOptions/ToppingOptionRadioSelector"
 import { useAuthStore } from "@/lib/AuthStore"
@@ -180,16 +180,22 @@ export default function StoreImageUploadPage() {
                         </Button>
                     </Box>
                 ) : (
-                    <Button variant="contained" component="label"
-                        className="w-full mb-2">
-                        画像を選択
-                        <input
-                            type="file"
-                            accept="image/jpeg,image/png,image/gif,image/webp"
-                            hidden
-                            onChange={handleImageChange}
-                        />
-                    </Button>
+                    <label htmlFor="image-upload-input">
+                        <Button
+                            variant="contained"
+                            component="span"
+                            className="w-full mb-2"
+                        >
+                            画像を選択
+                            <input
+                                id="image-upload-input"
+                                type="file"
+                                accept="image/jpeg,image/png,image/gif,image/webp"
+                                hidden
+                                onChange={handleImageChange}
+                            />
+                        </Button>
+                    </label>
                 )}
                 {errors.imageFile && (
                     <Typography color="error" variant='body2' className='mt-2'>
@@ -206,17 +212,26 @@ export default function StoreImageUploadPage() {
                 <Controller
                     name="menuType" control={control}
                     render={({ field }) => (
-                        <TextField
-                            select label="メニュータイプ" {...field}
-                            fullWidth className="mb-4"
-                            size="small" required
-                        >
-                            {MENU_TYPE.map(menu => (
-                                <MenuItem key={menu.value} value={menu.value}>
-                                    {menu.label}
-                                </MenuItem>
-                            ))}
-                        </TextField>
+                        <FormControl fullWidth size="small" required>
+                            <InputLabel
+                                id="menu-type-label"
+                            >メニュータイプ
+                            </InputLabel>
+                            <Select
+                                {...field}
+                                labelId="menu-type-label"
+                                id="menu-type"
+                                label="メニュータイプ"
+                                fullWidth
+                                className="mb-4"
+                            >
+                                {MENU_TYPE.map(menu => (
+                                    <MenuItem key={menu.value} value={menu.value}>
+                                        {menu.label}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
                     )}
                 />
                 <Controller


### PR DESCRIPTION
incorrect use of <label for=FORM_ELEMENT>
The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form and accessibility tools from working correctly.

To fix this issue, make sure the label's for attribute references the correct id of a form field.
の対応。

現状、下記情報（エラーではない）が出力されている状況だが、
Material UIでは現状上記メッセージが出力されるのは仕様通りなのか、
対応可能なのかをファクトチェックしてほしい。

<label> isn't associated with a form field.
To fix this issue, nest the <input> in the <label> or provide a for attribute on the <label> that matches a form field id.

該当箇所は下記のLabel（開始タグのlabelの箇所）です。

<label class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined mui-hvjq6j-MuiFormLabel-root-MuiInputLabel-root" data-shrink="true" id="menu-type-label">メニュータイプ<span aria-hidden="true" class="MuiFormLabel-asterisk MuiInputLabel-asterisk mui-1ljffdk-MuiFormLabel-asterisk"> *</span></label>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 画像ファイル選択ボタンとメニュータイプ選択UIのデザインとアクセシビリティを改善しました。  
  - メニュータイプ選択がより分かりやすい表示になりました。  
  - フォーム操作時のラベルや選択部分の見やすさが向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->