### PR TITLE
画像登録と編集画面の関数共通化（リファクタリング対応）

### DIFF
--- a/src/app/stores/images/[id]/edit/[imageId]/page.tsx
+++ b/src/app/stores/images/[id]/edit/[imageId]/page.tsx
@@ -106,7 +106,7 @@ export default function ImageUpdatePage() {
         if (isImageError && imageError) {
             errors.push(`画像データ取得失敗：${(imageError as Error).message}`)
         }
-        if (isToppingError && isToppingError) {
+        if (isToppingError && toppingErrorMessage) {
             errors.push(`トッピングコール情報取得失敗：${toppingErrorMessage}`)
         }
         return errors.join('\n')

--- a/src/app/stores/images/[id]/edit/[imageId]/page.tsx
+++ b/src/app/stores/images/[id]/edit/[imageId]/page.tsx
@@ -1,18 +1,13 @@
 "use client"
 
 import { useParams, useRouter } from 'next/navigation'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useAuthStore } from '@/lib/AuthStore'
-import { useForm } from 'react-hook-form'
-import { imageEditFormSchema, ImageEditFormValues, validateFileSizeBeforeCompression } from '@/validations/image'
-import { zodResolver } from '@hookform/resolvers/zod'
-import imageCompression from "browser-image-compression"
-import { SelectedToppingInfo } from '@/types/Image'
+import { ImageEditFormValues } from '@/validations/image'
 import LoadingErrorContainer from '@/components/feedback/LoadingErrorContainer'
-import { SimulationToppingOption } from '@/types/ToppingCall'
-import { useApiError } from '@/hooks/useApiError'
-import { useStoreImage, useStoreToppingCallsForImage, useUpdateStoreImage } from '@/hooks/api/useImages'
+import { useStoreImage, useUpdateStoreImage } from '@/hooks/api/useImages'
 import { StoreImageForm } from '@/components/StoreImageForm'
+import { useImageForm } from '@/hooks/useImageForm'
 
 /**
  * 画像編集画面
@@ -23,23 +18,9 @@ export default function ImageUpdatePage() {
     const user = useAuthStore((state) => state.user)
     // 画像更新用のmutation
     const updateImageMutation = useUpdateStoreImage()
-    const [imageUrl, setImageUrl] = useState('')
-    const [selectedToppingInfo, setSelectedToppingInfo] = useState<Record<string, SelectedToppingInfo>>({})
     const [updating, setUpdating] = useState<boolean>(false)
     const [successMsg, setSuccessMsg] = useState<string>("")
 
-    // API エラーハンドリング
-    const { errorMessage, validationErrors, setError, clearErrors } = useApiError()
-
-    // react-hook-form+zod定義
-    const { control, handleSubmit, setValue, formState: { errors }, reset } = useForm<ImageEditFormValues>({
-        resolver: zodResolver(imageEditFormSchema),
-        defaultValues: {
-            menuType: "",
-            menuName: "",
-            imageFile: undefined
-        }
-    })
 
     const router = useRouter()
     const params = useParams()
@@ -48,82 +29,43 @@ export default function ImageUpdatePage() {
     const storeId = params.id as string
     const imageId = params.imageId as string
 
-    // 画像情報取得
     const { data: imageData, isLoading: isImageLoading, isError: isImageError, error: imageError }
         = useStoreImage(storeId, imageId)
 
-    // トッピングコール情報取得
-    const { data: toppingCallData, isLoading: isToppingCallLoading, isError: isToppingCallError, error: toppingCallError }
-        = useStoreToppingCallsForImage(storeId)
 
-    const toppingOptions: SimulationToppingOption[]
-        = toppingCallData?.formattedToppingOptions?.map(([, opt]) => opt) ?? []
-
-    useEffect(() => {
-        if (imageData) {
-            const data = imageData
-
-            // フォームフィールドの初期値設定
-            reset({
-                menuName: data.menu_name,
-                menuType: String(data.menu_type),
-                imageFile: undefined
-            })
-            setImageUrl(data.image_url)
-
-            // トッピング選択状態の初期設定
-            const initialToppingInfo: Record<string, SelectedToppingInfo> = {}
-            data.topping_selections?.forEach((selection) => {
-                initialToppingInfo[String(selection.topping_id)] = {
-                    optionId: String(selection.call_option_id),
-                    storeToppingCallId: String(selection.store_topping_call_id)
-                }
-            })
-            setSelectedToppingInfo(initialToppingInfo)
+    const initialDataForForm = useMemo(() => {
+        if (!imageData) return undefined
+        return {
+            menuName: imageData.menu_name,
+            menuType: String(imageData.menu_type),
+            imageUrl: imageData.image_url,
+            toppingSelections: imageData.topping_selections
         }
-    }, [imageData, reset])
+    }, [imageData])
 
-    // 画像選択・リサイズ
-    const handleImageChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0]
-        if (!file) return
-        try {
-            // ファイル圧縮前のサイズチェック（圧縮前のサイズが２０MBを超えた場合エラー）
-            validateFileSizeBeforeCompression(file)
-
-            // ファイル画像圧縮処理
-            const compressed = await imageCompression(file, {
-                maxWidthOrHeight: 1080,
-                maxSizeMB: 5,   // 圧縮後のファイルサイズ
-                useWebWorker: true
-            })
-            // Blob→File型に変換
-            const compressedFile = compressed instanceof File
-                ? compressed
-                : new File([compressed], file.name, {
-                    type: file.type,
-                    lastModified: Date.now()
-                })
-            setImageUrl(URL.createObjectURL(compressedFile))
-            setValue("imageFile", compressedFile, { shouldValidate: true })
-        } catch (err) {
-            setError(err instanceof Error ? err : new Error('画像の最適化に失敗しました'))
-        }
-    }, [setValue, setError])
-
-    // 画像削除
-    const handleImageRemove = useCallback(() => {
-        setImageUrl("")
-        setValue("imageFile", undefined, { shouldValidate: true })
-    }, [setValue])
-
-    // トッピング選択
-    const handleOptionChange = useCallback((toppingId: string, optionId: string, storeToppingCallId: string) => {
-        setSelectedToppingInfo(prev => ({
-            ...prev,
-            [toppingId]: { optionId, storeToppingCallId }
-        }))
-    }, [])
+    const {
+        control,
+        handleSubmit,
+        errors,
+        imageUrl,
+        handleImageChange,
+        handleImageRemove,
+        toppingOptions,
+        selectedToppingInfo,
+        handleOptionChange,
+        errorMessage,
+        validationErrors,
+        clearErrors,
+        setError,
+        isToppingLoading,
+        isToppingError,
+        toppingErrorMessage,
+        createSubmitData
+    } = useImageForm({
+        mode: 'edit',
+        storeId,
+        initialData: initialDataForForm
+    })
 
     // 画像ファイルアップロード
     const onSubmit = async (values: ImageEditFormValues) => {
@@ -141,31 +83,7 @@ export default function ImageUpdatePage() {
                 return
             }
 
-            let base64 = null
-            if (values.imageFile) {
-                base64 = await new Promise<string>((resolve, reject) => {
-                    const reader = new FileReader()
-                    reader.onload = () => resolve(reader.result as string)
-                    reader.onerror = reject
-                    reader.readAsDataURL(values.imageFile!)
-                })
-            }
-
-            const toppingSelections = Object.entries(selectedToppingInfo).map(([toppingId, info]) => ({
-                topping_id: Number(toppingId),
-                call_option_id: Number(info.optionId),
-                ...(info.storeToppingCallId ? { store_topping_call_id: info.storeToppingCallId } : {})
-            }))
-
-            const editImageData = {
-                store_id: storeId,
-                user_id: user.uid,
-                menu_type: Number(values.menuType),
-                menu_name: values.menuName,
-                // 既存の画像に変更がない場合は image_base64 フィールドを省略する
-                ...(values.imageFile ? { image_base64: base64 } : {}),
-                ...(toppingSelections.length > 0 ? { topping_selections: toppingSelections } : {})
-            }
+            const editImageData = await createSubmitData(values, user.uid)
             await updateImageMutation.mutateAsync({ storeId, imageId, imageData: editImageData })
             clearErrors() // 成功時はエラーをクリア
             setSuccessMsg('画像情報更新が完了しました')
@@ -178,8 +96,8 @@ export default function ImageUpdatePage() {
     }
 
     // 初期表示時のローディング
-    const isLoading = isImageLoading || isToppingCallLoading
-    const hasError = isImageError || isToppingCallError
+    const isLoading = isImageLoading || isToppingLoading
+    const hasError = isImageError || isToppingError
 
     // エラーメッセージを統合
     const getErrorMessage = (): string | null => {
@@ -188,8 +106,8 @@ export default function ImageUpdatePage() {
         if (isImageError && imageError) {
             errors.push(`画像データ取得失敗：${(imageError as Error).message}`)
         }
-        if (isToppingCallError && toppingCallError) {
-            errors.push(`トッピングコール情報取得失敗：${(toppingCallError as Error).message}`)
+        if (isToppingError && isToppingError) {
+            errors.push(`トッピングコール情報取得失敗：${toppingErrorMessage}`)
         }
         return errors.join('\n')
     }

--- a/src/app/stores/simulation/answer/page.tsx
+++ b/src/app/stores/simulation/answer/page.tsx
@@ -65,7 +65,6 @@ export default function AnswerPage() {
             >
                 Map画面へ
             </Button>
-
         </Box>
     )
 }

--- a/src/components/StoreImageForm.tsx
+++ b/src/components/StoreImageForm.tsx
@@ -76,7 +76,9 @@ export function StoreImageForm({
                                 src={imageUrl}
                                 alt="選択したラーメン画像"
                                 fill
+                                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                                 style={{ objectFit: "contain" }}
+                                priority
                             />
                         </Box>
                         <Button variant="outlined" color="secondary" onClick={onImageRemove}>

--- a/src/hooks/useImageForm.ts
+++ b/src/hooks/useImageForm.ts
@@ -1,0 +1,255 @@
+import { SelectedToppingInfo } from "@/types/Image";
+import { SimulationToppingOption } from "@/types/ToppingCall";
+import { ExpressValidationError } from "@/types/validation";
+import { imageEditFormSchema, ImageEditFormValues, imageUploadFormSchema, ImageUploadFormValues, validateFileSizeBeforeCompression } from "@/validations/image";
+import { useCallback, useEffect, useState } from "react";
+import { Control, FieldErrors, useForm, UseFormHandleSubmit, UseFormReset, UseFormSetValue } from "react-hook-form";
+import { useApiError } from "./useApiError";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useStoreToppingCallsForImage } from "./api/useImages";
+import imageCompression from "browser-image-compression"
+
+// フォームの共通型定義
+type ImageFormValues = ImageUploadFormValues | ImageEditFormValues
+
+interface UseImageFormOptions {
+    mode: 'create' | 'edit';
+    storeId: string
+    initialData?: {
+        menuName?: string;
+        menuType?: string;
+        imageUrl?: string;
+        toppingSelections?: Array<{
+            topping_id: number | string;
+            call_option_id: number | string;
+            store_topping_call_id: number | string;
+        }>
+    }
+}
+
+interface UseImageFormReturn {
+    // React Hook Form
+    control: Control<ImageFormValues>;
+    handleSubmit: UseFormHandleSubmit<ImageFormValues>;
+    errors: FieldErrors<ImageFormValues>;
+    reset: UseFormReset<ImageFormValues>;
+    setValue: UseFormSetValue<ImageFormValues>;
+
+    // 画像関連
+    imageUrl: string;
+    handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+    handleImageRemove: () => void;
+
+    // トッピング関連
+    toppingOptions: SimulationToppingOption[];
+    selectedToppingInfo: Record<string, SelectedToppingInfo>;
+    handleOptionChange: (toppingId: string, optionId: string, storeToppingCallId: string) => void;
+
+    // エラーハンドリング
+    errorMessage: string | null
+    validationErrors: ExpressValidationError[];
+    setError: (error: unknown) => void;
+    clearErrors: () => void
+
+    // ローディング状態
+    isToppingLoading: boolean;
+    isToppingError: boolean;
+    toppingErrorMessage: string | null;
+
+    // 送信データ生成
+    createSubmitData: (values: ImageFormValues, userId: string) => Promise<{
+        store_id: string;
+        user_id: string;
+        menu_type: number;
+        menu_name: string;
+        image_base64?: string;
+        topping_selections?: Array<{
+            topping_id: number;
+            call_option_id: number;
+            store_topping_call_id?: string;
+        }>
+    }>
+}
+
+export function useImageForm({ mode, storeId, initialData }: UseImageFormOptions): UseImageFormReturn {
+    // 画像URL状態
+    const [imageUrl, setImageUrl] = useState('')
+    // トッピング選択状態
+    const [selectedToppingInfo, setSelectedToppingInfo]
+        = useState<Record<string, SelectedToppingInfo>>({})
+
+    // API エラーハンドリング
+    const { errorMessage, validationErrors, setError, clearErrors } = useApiError()
+
+    // トッピングコール情報取得
+    const {
+        data: toppingCallData,
+        isLoading: isToppingLoading,
+        isError: isToppingError,
+        error: toppingError
+    }
+        = useStoreToppingCallsForImage(storeId)
+
+    const toppingOptions: SimulationToppingOption[]
+        = toppingCallData?.formattedToppingOptions?.map(([, opt]) => opt) ?? []
+
+    const toppingErrorMessage = isToppingError ? (toppingError as Error).message : null
+
+    // フォームスキーマの選択
+    const schema = mode === 'create' ? imageUploadFormSchema : imageEditFormSchema
+
+    // フォームのデフォルト値設定
+    const defaultValues = mode === 'create'
+        ? {
+            menuType: "1",
+            menuName: "",
+            imageFile: undefined
+        }
+        : {
+            menuType: initialData?.menuType || "",
+            menuName: initialData?.menuName || "",
+            imageFile: undefined
+        }
+
+    // react-hook-form+zod定義
+    const { control, handleSubmit, setValue, formState: { errors }, reset }
+        = useForm<ImageEditFormValues>({
+            resolver: zodResolver(schema),
+            defaultValues
+        })
+
+    // 編集モードの初期化処理
+    useEffect(() => {
+        if (mode === 'edit' && initialData) {
+
+            // フォームフィールドの初期値設定
+            reset({
+                menuName: initialData.menuName || "",
+                menuType: initialData.menuType || "",
+                imageFile: undefined
+            })
+            // 画像URLの設定
+            if (initialData.imageUrl) {
+                setImageUrl(initialData.imageUrl)
+            }
+
+            // トッピング選択状態の初期設定
+            if (initialData.toppingSelections) {
+                const initialToppingInfo: Record<string, SelectedToppingInfo> = {}
+                initialData.toppingSelections.forEach((selection) => {
+                    initialToppingInfo[String(selection.topping_id)] = {
+                        optionId: String(selection.call_option_id),
+                        storeToppingCallId: String(selection.store_topping_call_id)
+                    }
+                })
+                setSelectedToppingInfo(initialToppingInfo)
+            }
+        }
+    }, [mode, initialData, reset])
+
+    // 画像選択・リサイズ
+    const handleImageChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) return
+        try {
+            // ファイル圧縮前のサイズチェック（圧縮前のサイズが２０MBを超えた場合エラー）
+            validateFileSizeBeforeCompression(file)
+
+            // ファイル画像圧縮処理
+            const compressed = await imageCompression(file, {
+                maxWidthOrHeight: 1080,
+                maxSizeMB: 5,   // 圧縮後のファイルサイズ
+                useWebWorker: true
+            })
+            // Blob→File型に変換
+            const compressedFile = compressed instanceof File
+                ? compressed
+                : new File([compressed], file.name, {
+                    type: file.type,
+                    lastModified: Date.now()
+                })
+            setImageUrl(URL.createObjectURL(compressedFile))
+            setValue("imageFile", compressedFile, { shouldValidate: true })
+        } catch (err) {
+            setError(err instanceof Error ? err : new Error('画像の最適化に失敗しました'))
+        }
+    }, [setValue, setError])
+
+    // 画像削除
+    const handleImageRemove = useCallback(() => {
+        setImageUrl("")
+        setValue("imageFile", undefined, { shouldValidate: true })
+    }, [setValue])
+
+    // トッピング選択
+    const handleOptionChange = useCallback((toppingId: string, optionId: string, storeToppingCallId: string) => {
+        setSelectedToppingInfo(prev => ({
+            ...prev,
+            [toppingId]: { optionId, storeToppingCallId }
+        }))
+    }, [])
+
+    // 画像ファイルアップロード
+    const createSubmitData = useCallback(async (values: ImageFormValues, userId: string) => {
+        // 画像ファイルのBase64変換
+        let base64: string | undefined
+
+        if (values.imageFile) {
+            base64 = await new Promise<string>((resolve, reject) => {
+                const reader = new FileReader()
+                reader.onload = () => resolve(reader.result as string)
+                reader.onerror = reject
+                reader.readAsDataURL(values.imageFile!)
+            })
+        }
+
+        const toppingSelections = Object.entries(selectedToppingInfo).map(([toppingId, info]) => ({
+            topping_id: Number(toppingId),
+            call_option_id: Number(info.optionId),
+            ...(info.storeToppingCallId ? { store_topping_call_id: String(info.storeToppingCallId) } : {})
+        }))
+
+        return {
+            store_id: storeId,
+            user_id: userId,
+            menu_type: Number(values.menuType),
+            menu_name: values.menuName,
+            // 既存の画像に変更がない場合は image_base64 フィールドを省略する
+            ...(base64 ? { image_base64: base64 } : {}),
+            ...(toppingSelections.length > 0 ? { topping_selections: toppingSelections } : {})
+        }
+    }, [selectedToppingInfo, storeId])
+
+    return {
+        // React Hook Form
+        control,
+        handleSubmit,
+        errors,
+        reset,
+        setValue,
+
+        // 画像関連
+        imageUrl,
+        handleImageChange,
+        handleImageRemove,
+
+        // トッピング関連
+        toppingOptions,
+        selectedToppingInfo,
+        handleOptionChange,
+
+        // エラーハンドリング
+        errorMessage,
+        validationErrors,
+        setError,
+        clearErrors,
+
+        // ローディング状態
+        isToppingLoading,
+        isToppingError,
+        toppingErrorMessage,
+
+        // 送信データ生成
+        createSubmitData
+    }
+}


### PR DESCRIPTION
画像登録画面と編集画面にあった、関数で、共通化できるものをカスタムフック化しました。
（react-hook-formやアップロードデータの作成、トッピング選択など）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - 画像編集およびアップロードページのフォームロジック・画像処理・トッピング選択・エラー管理をカスタムフックに移譲し、ページの記述を簡素化しました。

- **新機能**
  - 画像フォーム処理用のカスタムフックを導入し、画像の圧縮・トッピング選択・エラー管理・バリデーションを統合しました。
  - 画像表示にレスポンシブ対応の`sizes`属性と優先読み込みの`priority`属性を追加しました。

- **スタイル**
  - 一部コンポーネントの余分な空行を削除し、コードの可読性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->