### PR TITLE
Fast Refreshエラー対応、useThemeアンチパターン対応

### DIFF
--- a/src/app/stores/simulation/afterfinish/page.tsx
+++ b/src/app/stores/simulation/afterfinish/page.tsx
@@ -98,7 +98,7 @@ export default function AfterFinishPage() {
                         borderRadius: 4,
                         boxShadow: 6,
                         overflow: "hidden",
-                        bgcolor: theme.palette.mode === "dark" ? "gray.800" : "gray.100",
+                        bgcolor: theme.palette.mode === "dark" ? "grey.800" : "grey.100",
                         height: 200, width: 200,
                         mx: "auto", mb: 4
                     })}

--- a/src/app/stores/simulation/afterfinish/page.tsx
+++ b/src/app/stores/simulation/afterfinish/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ArrowForward } from "@mui/icons-material";
-import { Box, Button, Card, CardMedia, Checkbox, FormControlLabel, FormGroup, Typography, useTheme } from "@mui/material";
+import { Box, Button, Card, CardMedia, Checkbox, FormControlLabel, FormGroup, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -29,7 +29,6 @@ interface CheckItemsState {
  */
 
 export default function AfterFinishPage() {
-    const theme = useTheme()
     const router = useRouter()
 
     // チェックボックスの状態管理
@@ -73,29 +72,36 @@ export default function AfterFinishPage() {
         <Box
             display="flex" flexDirection="column" alignItems="center"
             justifyContent="center" px={{ xs: 2, md: 4 }}
-            width="100%"
+            py={{ xs: 4, md: 8 }} width="100%"
         >
             <Box
                 width="100%" maxWidth={560} bgcolor="#cac8c8"
-                borderRadius={4} color={theme.palette.text.primary}
+                borderRadius={4}
+                sx={(theme) => ({
+                    color: theme.palette.text.primary
+                })}
                 py={2}
             >
                 <Typography
                     variant="h6" fontWeight="bold" textAlign="center"
-                    mb={{ xs: 2, md: 4 }} color={theme.palette.text.primary}
+                    mb={{ xs: 2, md: 4 }}
                     pt={4}
+                    sx={(theme) => ({
+                        color: theme.palette.text.primary
+                    })}
+
                 >
                     完食後ルールクイズ
                 </Typography>
                 <Card
-                    sx={{
+                    sx={(theme) => ({
                         borderRadius: 4,
                         boxShadow: 6,
                         overflow: "hidden",
                         bgcolor: theme.palette.mode === "dark" ? "gray.800" : "gray.100",
                         height: 200, width: 200,
                         mx: "auto", mb: 4
-                    }}
+                    })}
                 >
                     <CardMedia
                         component="img"

--- a/src/app/stores/simulation/answer/page.tsx
+++ b/src/app/stores/simulation/answer/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Map } from "@mui/icons-material";
-import { Box, Button, Typography, useTheme } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { useRouter, useSearchParams } from "next/navigation";
 
 /**
@@ -16,7 +16,6 @@ import { useRouter, useSearchParams } from "next/navigation";
  */
 
 export default function AnswerPage() {
-    const theme = useTheme()
     const params = useSearchParams()
     const result = params.get('result') ?? ''
     const router = useRouter()
@@ -27,13 +26,13 @@ export default function AnswerPage() {
             flexDirection="column"
             alignItems="center"
             px={{ xs: 4, md: 8 }} py={{ xs: 4, md: 8 }}
-            sx={{
+            sx={(theme) => ({
                 maxWidth: "42rem",
                 mx: "auto",
-                minHeight: "100vh"
-            }}
+                minHeight: "100vh",
+                color: theme.palette.text.primary
+            })}
             bgcolor="#cac8c8"
-            color={theme.palette.text.primary}
             width="100%"
         >
             <Typography

--- a/src/app/stores/simulation/postcall/page.tsx
+++ b/src/app/stores/simulation/postcall/page.tsx
@@ -82,7 +82,7 @@ export default function PostcallPage() {
                     borderRadius: 4,
                     boxShadow: 6,
                     overflow: "hidden",
-                    bgcolor: theme.palette.mode === "dark" ? "gray.800" : "white"
+                    bgcolor: theme.palette.mode === "dark" ? "grey.800" : "background.paper"
 
                 })}
             >
@@ -131,7 +131,7 @@ export default function PostcallPage() {
                         bgcolor: theme.palette.mode === "dark" ? "grey.800" : "white",
                         color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.secondary.main,
                         "&:hover": {
-                            bgcolor: theme.palette.mode === "dark" ? "gray.700" : "gray.100"
+                            bgcolor: theme.palette.mode === "dark" ? "grey.700" : "grey.100"
                         }
                     })}
                 >

--- a/src/app/stores/simulation/postcall/page.tsx
+++ b/src/app/stores/simulation/postcall/page.tsx
@@ -5,7 +5,7 @@ import { ToppingOptionSelector } from "@/components/simulation/ToppingOptionSele
 import { useStoreToppingCalls } from "@/hooks/api/useToppingCalls"
 import { generateCallText } from "@/utils/toppingFormatter"
 import { ArrowForward, Block } from "@mui/icons-material"
-import { Alert, Box, Button, Card, CardMedia, Typography, useTheme } from "@mui/material"
+import { Alert, Box, Button, Card, CardMedia, Typography } from "@mui/material"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useMemo, useState } from "react"
 
@@ -16,7 +16,6 @@ import { useCallback, useMemo, useState } from "react"
  * - 選択されたトッピングコール情報をもとに、コールテキストを生成し、ResultPageに遷移。
  */
 export default function PostcallPage() {
-    const theme = useTheme()
     const router = useRouter()
     const params = useSearchParams()
     const id = params.get("id") ?? ""
@@ -69,7 +68,9 @@ export default function PostcallPage() {
                 variant="h6"
                 fontWeight="bold"
                 className="mb-8"
-                color={theme.palette.mode === "dark" ? "primary.light" : theme.palette.text.primary}
+                sx={(theme) => ({
+                    color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.text.primary
+                })}
             >
                 着丼前コールシミュレーション
             </Typography>
@@ -77,12 +78,13 @@ export default function PostcallPage() {
 
             <Card
                 className="mb-8"
-                sx={{
+                sx={(theme) => ({
                     borderRadius: 4,
                     boxShadow: 6,
                     overflow: "hidden",
-                    bgcolor: theme.palette.mode === "dark" ? "gray.900" : "white"
-                }}
+                    bgcolor: theme.palette.mode === "dark" ? "gray.800" : "white"
+
+                })}
             >
                 <CardMedia
                     component="img"
@@ -94,7 +96,9 @@ export default function PostcallPage() {
             <Typography
                 variant="body1"
                 className="mb-8 whitespace-pre-line"
-                color={theme.palette.text.primary}
+                sx={(theme) => ({
+                    color: theme.palette.text.primary
+                })}
             >
                 ラーメンが出来上がりました。{'\n'}
                 店員さんから{'\n'}
@@ -119,18 +123,17 @@ export default function PostcallPage() {
             <Box display="flex" gap={4} mt={8} justifyContent="center" sx={{ width: "100%" }}>
                 <Button
                     variant="outlined"
-                    color={theme.palette.mode === "dark" ? "primary" : "secondary"}
                     startIcon={<Block />}
                     onClick={() => router.push(`/stores/simulation/afterfinish`)}
-                    sx={{
+                    sx={(theme) => ({
                         borderWidth: 2,
                         fontWeight: "bold",
                         bgcolor: theme.palette.mode === "dark" ? "grey.800" : "white",
-                        color: theme.palette.mode === "dark" ? "primary.light" : "secondary.main",
+                        color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.secondary.main,
                         "&:hover": {
                             bgcolor: theme.palette.mode === "dark" ? "gray.700" : "gray.100"
                         }
-                    }}
+                    })}
                 >
                     コール無し
                 </Button>

--- a/src/app/stores/simulation/precall/page.tsx
+++ b/src/app/stores/simulation/precall/page.tsx
@@ -5,7 +5,7 @@ import { ToppingOptionSelector } from "@/components/simulation/ToppingOptionSele
 import { useStoreToppingCalls } from "@/hooks/api/useToppingCalls"
 import { generateCallText } from "@/utils/toppingFormatter"
 import { ArrowForward, Block } from "@mui/icons-material"
-import { Alert, Box, Button, Card, CardMedia, Typography, useTheme } from "@mui/material"
+import { Alert, Box, Button, Card, CardMedia, Typography } from "@mui/material"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useMemo, useState } from "react"
 
@@ -16,7 +16,6 @@ import { useCallback, useMemo, useState } from "react"
  * - 選択されたトッピングコール情報をもとに、コールテキストを生成し、ResultPageに遷移。
  */
 export default function PrecallPage() {
-    const theme = useTheme()
     const router = useRouter()
     const params = useSearchParams()
     const id = params.get("id") ?? ""
@@ -68,7 +67,9 @@ export default function PrecallPage() {
                 variant="h6"
                 fontWeight="bold"
                 className="mb-8"
-                color={theme.palette.mode === "dark" ? "primary.light" : theme.palette.text.secondary}
+                sx={(theme) => ({
+                    color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.text.secondary
+                })}
             >
                 事前コールシミュレーション
             </Typography>
@@ -76,12 +77,13 @@ export default function PrecallPage() {
 
             <Card
                 className="mb-8"
-                sx={{
+                sx={(theme) => ({
                     borderRadius: 4,
                     boxShadow: 6,
                     overflow: "hidden",
                     bgcolor: theme.palette.mode === "dark" ? "gray.900" : "white"
-                }}
+
+                })}
             >
                 <CardMedia
                     component="img"
@@ -93,7 +95,10 @@ export default function PrecallPage() {
             <Typography
                 variant="body1"
                 className="mb-8 whitespace-pre-line"
-                color={theme.palette.text.primary}
+                sx={(theme) => ({
+                    color: theme.palette.text.primary
+                })}
+
             >
                 行列に並んでいると、店員さんから{"\n"}
                 「食券を見せてください」と言われました。{"\n"}
@@ -116,18 +121,17 @@ export default function PrecallPage() {
             <Box display="flex" gap={4} mt={8} justifyContent="center" sx={{ width: "100%" }}>
                 <Button
                     variant="outlined"
-                    color={theme.palette.mode === "dark" ? "primary" : "secondary"}
                     startIcon={<Block />}
                     onClick={() => router.push(`/stores/simulation/postcall?id=${id}`)}
-                    sx={{
+                    sx={(theme) => ({
                         borderWidth: 2,
                         fontWeight: "bold",
                         bgcolor: theme.palette.mode === "dark" ? "grey.800" : "white",
-                        color: theme.palette.mode === "dark" ? "primary.light" : "secondary.main",
+                        color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.secondary.main,
                         "&:hover": {
                             bgcolor: theme.palette.mode === "dark" ? "gray.700" : "gray.100"
                         }
-                    }}
+                    })}
                 >
                     コール無し
                 </Button>

--- a/src/app/stores/simulation/precall/page.tsx
+++ b/src/app/stores/simulation/precall/page.tsx
@@ -81,7 +81,7 @@ export default function PrecallPage() {
                     borderRadius: 4,
                     boxShadow: 6,
                     overflow: "hidden",
-                    bgcolor: theme.palette.mode === "dark" ? "gray.900" : "white"
+                    bgcolor: theme.palette.mode === "dark" ? "grey.900" : "background.paper"
 
                 })}
             >
@@ -126,10 +126,10 @@ export default function PrecallPage() {
                     sx={(theme) => ({
                         borderWidth: 2,
                         fontWeight: "bold",
-                        bgcolor: theme.palette.mode === "dark" ? "grey.800" : "white",
+                        bgcolor: theme.palette.mode === "dark" ? "grey.800" : "background.paper",
                         color: theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.secondary.main,
                         "&:hover": {
-                            bgcolor: theme.palette.mode === "dark" ? "gray.700" : "gray.100"
+                            bgcolor: theme.palette.mode === "dark" ? "grey.700" : "grey.100"
                         }
                     })}
                 >

--- a/src/components/Store/StoreMap.tsx
+++ b/src/components/Store/StoreMap.tsx
@@ -75,7 +75,7 @@ export default function StoreMap({ mapData }: StoreMapProps) {
         setDrawerOpen(true)
     }
 
-    if (isLocationLoading || errorMessage) {
+    if (isLocationLoading || errorMessage || !isMounted) {
         return <LoadingErrorContainer loading={isLocationLoading} error={errorMessage} />
     }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { useResponsive } from "@/hooks/useResponsive";
 import { useAuthStore } from "@/lib/AuthStore";
 import { auth } from "@/lib/firebase";
 import { AccountCircle, AddBusiness, Logout, Menu as MenuIcon, PersonAdd, School } from "@mui/icons-material";
-import { AppBar, Box, Button, IconButton, Menu, MenuItem, Toolbar, Typography, useTheme } from "@mui/material";
+import { AppBar, Box, Button, IconButton, Menu, MenuItem, Toolbar, Typography } from "@mui/material";
 import { signOut } from "firebase/auth";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
@@ -23,7 +23,6 @@ interface HeaderProps {
  */
 export function Header({ title = "J-Navi" }: HeaderProps) {
     const router = useRouter()
-    const theme = useTheme()
     const { isMobile } = useResponsive()
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
 
@@ -130,19 +129,19 @@ export function Header({ title = "J-Navi" }: HeaderProps) {
         return (
             <AppBar
                 position="sticky"
-                sx={{
+                sx={(theme) => ({
                     backgroundColor: theme.palette.grey[600],
                     boxShadow: theme.shadows[4]
-                }}
+                })}
             >
                 <Toolbar sx={{ justifyContent: "space-between" }}>
                     <Typography
                         variant="h6" component="div"
-                        sx={{
+                        sx={(theme) => ({
                             fontWeight: "bold",
                             cursor: "pointer",
                             color: theme.palette.text.primary
-                        }}
+                        })}
                         onClick={() => router.push('/stores/map')}
                     >
                         {title}
@@ -156,20 +155,20 @@ export function Header({ title = "J-Navi" }: HeaderProps) {
     return (
         <AppBar
             position="sticky"
-            sx={{
+            sx={(theme) => ({
                 backgroundColor: theme.palette.grey[600],
                 boxShadow: theme.shadows[4]
-            }}
+            })}
         >
             <Toolbar sx={{ justifyContent: "space-between" }}>
                 {/* アプリ名 */}
                 <Typography
                     variant="h6" component="div"
-                    sx={{
+                    sx={(theme) => ({
                         fontWeight: "bold",
                         cursor: "pointer",
                         color: theme.palette.text.primary
-                    }}
+                    })}
                     onClick={() => router.push('/stores/map')}
                 >
                     {title}
@@ -178,12 +177,11 @@ export function Header({ title = "J-Navi" }: HeaderProps) {
                 {/* ナビゲーション部分 - マウント後のみ表示 */}
                 <>
                     {/* デスクトップ用ナビゲーション */}
-                    {!isMobile ? (
+                    {(!isMobile) ? (
                         <Box display="flex" gap={2}>
                             {navigationItems.map((item) => (
                                 <Button
                                     key={item.id}
-                                    color="inherit"
                                     startIcon={item.icon}
                                     onClick={() => 'action' in item && item.action ? item.action() : handleNavigation?.(item.path!)}
                                     sx={{
@@ -193,7 +191,8 @@ export function Header({ title = "J-Navi" }: HeaderProps) {
                                         px: 2,
                                         "&:hover": {
                                             backgroundColor: "rgba(255, 255, 255, 0.1)"
-                                        }
+                                        },
+                                        color: "inherit"
                                     }}
                                 >
                                     {item.label}

--- a/src/components/simulation/CallResultScreen.tsx
+++ b/src/components/simulation/CallResultScreen.tsx
@@ -3,7 +3,7 @@
 import { useSpeechSynthesis } from "@/hooks/useSpeechSynthesis";
 import { cleanupSpeechSynthesis } from "@/lib/speech-synthesis";
 import { ArrowForward, PauseCircle, PlayCircle, StopCircle } from "@mui/icons-material";
-import { Box, Button, CircularProgress, IconButton, Typography, useTheme } from "@mui/material";
+import { Box, Button, CircularProgress, IconButton, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
 interface CallResultScreenProps {
     callText: string;
@@ -22,7 +22,6 @@ interface CallResultScreenProps {
  */
 export function CallResultScreen({ callText, nextHref, nextQuery }: CallResultScreenProps) {
     const router = useRouter()
-    const theme = useTheme()
     const { speak, cancel, pause, resume, isSpeaking, isPaused, isSupported, isMounted } = useSpeechSynthesis({
         rate: 0.8,
         pitch: 0.8,
@@ -82,7 +81,9 @@ export function CallResultScreen({ callText, nextHref, nextQuery }: CallResultSc
                 width="100%" maxWidth={560}
                 bgcolor="#cac8c8" borderRadius={4} boxShadow={4}
                 p={4} display="flex" flexDirection="column" alignItems="center"
-                color={theme.palette.text.primary}
+                sx={(theme) => ({
+                    color: theme.palette.text.primary
+                })}
             >
                 <Typography variant="h6" fontWeight="bold" sx={{ mb: 4, textAlign: "center" }}>
                     事前コール内容

--- a/src/components/simulation/ShopAutoComplete.tsx
+++ b/src/components/simulation/ShopAutoComplete.tsx
@@ -1,6 +1,6 @@
 import { useDebounce } from "@/hooks/useDebounce";
 import { SimulationSelectStoresData } from "@/types/Store";
-import { Autocomplete, TextField, useTheme } from "@mui/material";
+import { Autocomplete, TextField } from "@mui/material";
 import { useMemo, useState } from "react";
 
 interface ShopAutocompleteProps {
@@ -21,7 +21,6 @@ interface ShopAutocompleteProps {
 export function ShopAutocomplete({ stores, selectedStore, onChange }: ShopAutocompleteProps) {
     const [inputValue, setInputValue] = useState('')
     const debouncedInputValue: string = useDebounce(inputValue, 300)
-    const theme = useTheme()
 
     // デバウンスされた入力値に基づいてフィルタリング
     const filteredStores = useMemo(() => {
@@ -63,7 +62,7 @@ export function ShopAutocomplete({ stores, selectedStore, onChange }: ShopAutoco
                     fullWidth
                     margin="normal"
                     size="small"
-                    sx={{
+                    sx={(theme) => ({
                         backgroundColor: theme.palette.background.paper,
                         "& .MuiOutlinedInput-root": {
                             "& fieldset": {
@@ -85,10 +84,10 @@ export function ShopAutocomplete({ stores, selectedStore, onChange }: ShopAutoco
                                 color: theme.palette.primary.main,
                             }
                         }
-                    }}
+                    })}
                 />
             )}
-            sx={{
+            sx={(theme) => ({
                 "& .MuiAutocomplete-paper": {
                     boxShadow: theme.shadows[8],
                     backgroundColor: theme.palette.background.paper,
@@ -104,7 +103,7 @@ export function ShopAutocomplete({ stores, selectedStore, onChange }: ShopAutoco
                         color: theme.palette.primary.contrastText,
                     }
                 }
-            }}
+            })}
         />
     )
 }

--- a/src/components/simulation/ToppingOptionSelector.tsx
+++ b/src/components/simulation/ToppingOptionSelector.tsx
@@ -1,5 +1,5 @@
 import { SimulationToppingOption } from "@/types/ToppingCall";
-import { Box, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, useTheme } from "@mui/material";
+import { Box, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from "@mui/material";
 
 interface ToppingOptionSelectorProps {
     options: SimulationToppingOption[];
@@ -20,7 +20,6 @@ interface ToppingOptionSelectorProps {
  */
 
 export function ToppingOptionSelector({ options, selectedOptions, onOptionChange }: ToppingOptionSelectorProps) {
-    const theme = useTheme()
 
     if (!options.length) return null
 
@@ -30,10 +29,10 @@ export function ToppingOptionSelector({ options, selectedOptions, onOptionChange
                 <FormControl key={option.toppingId} component="fieldset" fullWidth className="mb-4">
                     <FormLabel
                         component="legend"
-                        sx={{
+                        sx={(theme) => ({
                             color: theme.palette.text.primary,
                             fontWeight: "bold",
-                        }}
+                        })}
                     >
                         {option.toppingName}
                     </FormLabel>
@@ -50,9 +49,9 @@ export function ToppingOptionSelector({ options, selectedOptions, onOptionChange
                                     <Radio color="primary" />
                                 }
                                 label={opt.optionName}
-                                sx={{
+                                sx={(theme) => ({
                                     color: theme.palette.text.primary
-                                }}
+                                })}
                             />
                         ))}
                     </RadioGroup>

--- a/src/components/toppingCallOptions/ToppingOptionRadioSelector.tsx
+++ b/src/components/toppingCallOptions/ToppingOptionRadioSelector.tsx
@@ -1,6 +1,6 @@
 import { SelectedToppingInfo } from "@/types/Image";
 import { SimulationToppingOption } from "@/types/ToppingCall";
-import { Box, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, useTheme } from "@mui/material";
+import { Box, FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from "@mui/material";
 
 interface ToppingOptionRadioSelectorProps {
     options: SimulationToppingOption[];
@@ -26,7 +26,6 @@ export function ToppingOptionRadioSelector({
     selectedOptions,
     onOptionChange
 }: ToppingOptionRadioSelectorProps) {
-    const theme = useTheme()
     if (!options.length) return null
 
     return (
@@ -37,10 +36,10 @@ export function ToppingOptionRadioSelector({
                 >
                     <FormLabel
                         component="legend"
-                        sx={{
+                        sx={(theme) => ({
                             color: theme.palette.text.primary,
                             fontWeight: "bold",
-                        }}
+                        })}
                     >
                         {option.toppingName}
                     </FormLabel>
@@ -64,7 +63,7 @@ export function ToppingOptionRadioSelector({
                                 value={String(opt.optionId)}
                                 control={<Radio color="primary" />}
                                 label={opt.optionName}
-                                sx={{ color: theme.palette.text.primary }}
+                                sx={(theme) => ({ color: theme.palette.text.primary })}
                             />
                         ))}
                     </RadioGroup>


### PR DESCRIPTION
MapPageがサーバーコンポーネント（async）で、その中で直接StoreMapクライアントコンポーネントを使用していますが、Google Mapsライブラリはブラウザ専用のAPIを使用するため、サーバーサイドレンダリング時に問題が発生。

isMountedがtrueになるまで（＝クライアントサイドになるまで）Google Maps APIをレンダリングしない
これにより、サーバーサイドでブラウザ専用APIが実行されることを防ぐ

useThemeアンチパターン：
Material UIのテーマに依存したスタイリングは、sxプロパティ内でのコールバック関数を使用する

useResponsiveフックを活用：
既に存在するuseResponsiveフックを使用してレスポンシブ対応を行う

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * テーマ依存のスタイル指定を、`useTheme`フックの直接利用から`sx`プロップのコールバック形式に変更し、テーマに応じた動的なスタイリングを実現しました。
  * 一部コンポーネントで、色や背景色などのスタイル指定方法を統一しました。
  * ローディングやエラー表示のタイミングを調整し、マウント前にメインUIが表示されないよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->