### PR TITLE
現在地取得拒否の場合は東京駅を中心位置に固定に変更（エラー回避）

### DIFF
--- a/src/components/Store/StoreMap.tsx
+++ b/src/components/Store/StoreMap.tsx
@@ -83,7 +83,7 @@ export default function StoreMap({ mapData }: StoreMapProps) {
     }
 
     if (isLocationLoading || !isMounted) {
-        return <LoadingErrorContainer loading={isLocationLoading} error={null} />
+        return <LoadingErrorContainer loading={isLocationLoading || !isMounted} error={null} />
     }
 
     return (

--- a/src/components/Store/StoreMap.tsx
+++ b/src/components/Store/StoreMap.tsx
@@ -33,7 +33,6 @@ export default function StoreMap({ mapData }: StoreMapProps) {
     const [selectedStore, setSelectedStore] = useState<MapStore | null>(null)
     const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
     const [isLocationLoading, setIsLocationLoading] = useState(false)
-    const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const [isMounted, setIsMounted] = useState(false)
 
     useEffect(() => {
@@ -46,8 +45,9 @@ export default function StoreMap({ mapData }: StoreMapProps) {
 
         setIsLocationLoading(true)
         if (!navigator.geolocation) {
+            // 位置情報がサポートされていない場合は東京駅を使用
+            setCenter(defaultCenter)
             setIsLocationLoading(false)
-            setErrorMessage("位置情報取得の権限がありません。")
             return
         }
 
@@ -61,8 +61,9 @@ export default function StoreMap({ mapData }: StoreMapProps) {
             },
             (positionError) => {
                 console.error("現在地情報取得エラー：", positionError)
+                // 位置情報取得に失敗した場合は東京駅を使用
+                setCenter(defaultCenter)
                 setIsLocationLoading(false)
-                setErrorMessage("現在地情報取得に失敗しました")
             },
             {
                 enableHighAccuracy: true,
@@ -81,8 +82,8 @@ export default function StoreMap({ mapData }: StoreMapProps) {
         setDrawerOpen(true)
     }
 
-    if (isLocationLoading || errorMessage || !isMounted) {
-        return <LoadingErrorContainer loading={isLocationLoading} error={errorMessage} />
+    if (isLocationLoading || !isMounted) {
+        return <LoadingErrorContainer loading={isLocationLoading} error={null} />
     }
 
     return (


### PR DESCRIPTION
タイトルの通りです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **改善**
  * 位置情報取得に失敗した場合でもエラーメッセージが表示されなくなり、地図はデフォルトの場所（東京駅）を中心に表示するようになりました。  
  * ローディング中は引き続きローディング状態が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->