### PR TITLE
AuthForm見直し（プロバイダーボタンの色、Map画面遷移アイコン追加）

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -7,7 +7,7 @@
 import { signInWithEmail, signUpWithEmail } from "@/lib/auth"
 import { LoginFormInput, loginSchema, SignupFormInput, signupSchema } from "@/validations/auth"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Alert, Box, Button, CircularProgress, Divider, Typography } from "@mui/material"
+import { Alert, Box, Button, CircularProgress, Divider, IconButton, Typography } from "@mui/material"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { Control, useForm } from "react-hook-form"
@@ -21,6 +21,7 @@ import { auth } from "@/lib/firebase"
 import { ValidationErrorList } from "../feedback/validationErrorList"
 import { useApiError } from "@/hooks/useApiError"
 import { useAsyncOperation } from "@/hooks/useAsyncOperation"
+import MapIcon from '@mui/icons-material/Map';
 
 interface AuthFormProps {
     mode: 'login' | 'signup'
@@ -152,18 +153,45 @@ export function AuthForm({ mode }: AuthFormProps) {
             sx={{
                 maxWidth: 540,
                 mx: "auto",
+                my: 4,
                 p: 4,
                 backgroundColor: "grey.300",
                 color: "grey.700",
                 borderRadius: 2,
                 boxShadow: 2,
-                height: "100vh",
+                height: "88vh",
                 overflowY: "auto"
             }}
         >
-            <Typography variant="h5" fontWeight="bold" textAlign="center">
-                {isSignup ? "アカウント作成" : "ログイン"}
-            </Typography>
+            {/* タイトルとMapアイコンを横並びに配置 */}
+            <Box
+                sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    position: "relative",
+                    mb: 2
+                }}
+            >
+                <Typography variant="h5" fontWeight="bold" textAlign="center">
+                    {isSignup ? "アカウント作成" : "ログイン"}
+                </Typography>
+                <IconButton
+                    sx={{
+                        position: "absolute",
+                        right: 0,
+                        "&:hover": {
+                            backgroundColor: "primary.light",
+                            color: "black"
+                        }
+                    }}
+                    title="マップ画面"
+                    onClick={() => router.push('/stores/map')}
+                >
+                    <MapIcon />
+                </IconButton>
+
+            </Box>
 
             {/* エラーメッセージ表示（統一化） */}
             {errorMessage && (
@@ -223,7 +251,7 @@ export function AuthForm({ mode }: AuthFormProps) {
             )}
 
             <Button type="submit" variant="contained" fullWidth disabled={loading}
-                sx={{ mt: 4, mb: 4, py: 2, fontWeight: "bold" }}
+                sx={{ mt: 2, mb: 2, py: 2, fontWeight: "bold" }}
             >
                 {loading ? <CircularProgress size={24} color="inherit" /> : (isSignup ? "アカウント作成" : "ログイン")}
             </Button>

--- a/src/components/auth/AuthSocialButtons.tsx
+++ b/src/components/auth/AuthSocialButtons.tsx
@@ -64,32 +64,82 @@ export function AuthSocialButtons({ onError, onErrors }: AuthSocialButtonsProps)
     return (
         <Box display="flex" flexDirection="column" gap={2}>
             <Button
-                variant="outlined"
+                variant="contained"
                 fullWidth
                 startIcon={<Google />}
                 onClick={handleGoogleAuth}
-                sx={{ py: 1.5 }}
+                sx={{
+                    py: 1.5,
+                    backgroundColor: '#ffffff',
+                    color: '#1f1f1f',
+                    border: '1px solid #dadce0',
+                    boxShadow: 'none',
+                    '&:hover': {
+                        backgroundColor: '#f8f9fa',
+                        boxShadow: '0 1px 2px 0 rgba(60,64,67,.30), 0 1px 3px 1px rgba(60,64,67,.15)',
+                    },
+                    '&:active': {
+                        backgroundColor: '#f1f3f4',
+                    },
+                    '&:disabled': {
+                        backgroundColor: '#f8f9fa',
+                        color: '#5f6368',
+                    },
+                    '& .MuiButton-startIcon': {
+                        color: '#4285f4', // Google blue for icon
+                    }
+                }}
                 disabled={loading !== null}
             >
-                {loading === 'google' ? <CircularProgress size={24} color="inherit" /> : 'Googleでログイン'}
+                {loading === 'google' ? <CircularProgress size={24} sx={{ color: '#4285f4' }} /> : 'Googleでログイン'}
             </Button>
             <Button
-                variant="outlined"
+                variant="contained"
                 fullWidth
                 startIcon={<Facebook />}
                 onClick={handleFacebookAuth}
                 disabled={loading !== null}
-                sx={{ py: 1.5 }}
+                sx={{
+                    py: 1.5,
+                    backgroundColor: '#1877F2',
+                    color: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#166FE5',
+                        boxShadow: '0 2px 4px 0 rgba(0,0,0,0.2), 0 3px 10px 0 rgba(0,0,0,0.19)',
+                    },
+                    '&:active': {
+                        backgroundColor: '#1464D6',
+                    },
+                    '&:disabled': {
+                        backgroundColor: '#E4E6EA',
+                        color: '#BEC3C9',
+                    }
+                }}
             >
                 {loading === 'facebook' ? <CircularProgress size={24} color="inherit" /> : 'Facebookでログイン'}
             </Button>
             <Button
-                variant="outlined"
+                variant="contained"
                 fullWidth
                 startIcon={<GitHub />}
                 onClick={handleGitHubAuth}
                 disabled={loading !== null}
-                sx={{ py: 1.5 }}
+                sx={{
+                    py: 1.5,
+                    backgroundColor: '#24292e',
+                    color: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#1c2025',
+                        opacity: 0.8,
+                    },
+                    '&:active': {
+                        backgroundColor: '#181b20',
+                    },
+                    '&:disabled': {
+                        backgroundColor: '#f6f8fa',
+                        color: '#959da5',
+                    }
+                }}
             >
                 {loading === 'github' ? <CircularProgress size={24} color="inherit" /> : 'Githubでログイン'}
             </Button>


### PR DESCRIPTION
タイトルの通りです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 認証フォームのタイトル横にマップアイコンボタンを追加し、クリックで店舗マップページへ移動できるようになりました。

* **スタイル**
  * 認証フォームのレイアウトと余白を調整しました。
  * Google、Facebook、GitHubのソーシャルログインボタンのデザインをブランドカラーに合わせて改善し、視認性と一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->